### PR TITLE
修复 A/B Test 请求参数错误的问题

### DIFF
--- a/OpenSearch/Util/UrlParamsBuilder.php
+++ b/OpenSearch/Util/UrlParamsBuilder.php
@@ -161,7 +161,7 @@ class UrlParamsBuilder {
 
     public function initAbtest($searchParams) {
         if (isset($searchParams->abtest) && isset($searchParams->abtest->sceneTag) && isset($searchParams->abtest->flowDivider)) {
-            $this->params[self::ABTEST] = sprintf("%s=%s,%s=%s", Constant::get('ABTEST_PARAM_SCENE_TAG'), $searchParams->abtest->sceneTag, Constant::get('ABTEST_PARAM_FLOW_DIVIDER'), $searchParams->abtest->flowDivider);
+            $this->params[self::ABTEST] = sprintf("%s:%s,%s:%s", Constant::get('ABTEST_PARAM_SCENE_TAG'), $searchParams->abtest->sceneTag, Constant::get('ABTEST_PARAM_FLOW_DIVIDER'), $searchParams->abtest->flowDivider);
         }
     }
 

--- a/OpenSearch/composer.json
+++ b/OpenSearch/composer.json
@@ -10,7 +10,7 @@
             "email": "http://www.aliyun.com"
         }
     ],
-    "version": "v3.1.1",
+    "version": "v3.1.2",
     "require": {
 		"php": ">=5.3"
 	},


### PR DESCRIPTION
- Bug：A/B Test 的请求参数形式应为 ` scene_tag:xxx,flow_divider:xxx`
- 文档：https://help.aliyun.com/document_detail/89958.html?spm=5176.11065259.1996646101.searchclickresult.133a297fdY0W3Z